### PR TITLE
added zone affinity balancing strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,7 @@ jobs:
           command: sudo apt install default-jre
       - run:
           name: Test
-          command: |
-            sleep 20
-            make test
+          command: make test
 
 workflows:
   version: 2

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,22 +10,6 @@
   version = "v1.3.4"
 
 [[projects]]
-  digest = "1:f11e03e8297265765272534835027251cc808ed6dab124f5f5dbc37f7c908abb"
-  name = "github.com/Shopify/sarama"
-  packages = ["."]
-  pruneopts = ""
-  revision = "ec843464b50d4c8b56403ec9d589cf41ea30e722"
-  version = "v1.19.0"
-
-[[projects]]
-  digest = "1:6da5545112f73dbad12895d25e39818c1c3e8040ebba488d4d3fe43bc8685eb6"
-  name = "github.com/bsm/sarama-cluster"
-  packages = ["."]
-  pruneopts = ""
-  revision = "c618e605e15c0d7535f6c96ff8efbb0dba4fd66c"
-  version = "v2.1.15"
-
-[[projects]]
   digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -126,6 +110,14 @@
   version = "v2.0.2"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = ""
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   digest = "1:15bcdc717654ef21128e8af3a63eec39a6d08a830e297f93d65163f87c8eb523"
   name = "github.com/rcrowley/go-metrics"
@@ -134,12 +126,23 @@
   revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
 
 [[projects]]
-  branch = "update-producer-metadata-if-retries-disabled"
-  digest = "1:0415198484c99ebc28cfb1da098c56494e236e64a78c2a68acc649a732e622e7"
+  branch = "segment-stable"
+  digest = "1:d293ab31248cb34d3a02025a765ddb3880e598fd54c3d5cae66be8db71f39fbf"
   name = "github.com/segmentio/sarama"
   packages = ["."]
   pruneopts = ""
-  revision = "a15f23e1d4293d967923b800b1cd778494059079"
+  revision = "9884adb98272a7828b96fac83c665ce1589482f3"
+
+[[projects]]
+  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
+  name = "github.com/stretchr/testify"
+  packages = [
+    "assert",
+    "require",
+  ]
+  pruneopts = ""
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
@@ -199,11 +202,12 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/bsm/sarama-cluster",
     "github.com/onsi/ginkgo",
     "github.com/onsi/ginkgo/extensions/table",
     "github.com/onsi/gomega",
     "github.com/segmentio/sarama",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,4 +23,4 @@
 
 [[constraint]]
   name = "github.com/segmentio/sarama"
-  branch = "update-producer-metadata-if-retries-disabled"
+  branch = "segment-stable"

--- a/balancer.go
+++ b/balancer.go
@@ -70,100 +70,155 @@ func (n *Notification) success(current map[string][]int32) *Notification {
 
 // --------------------------------------------------------------------
 
-type topicInfo struct {
-	Partitions []int32
-	MemberIDs  []string
+// Member describes an individual participant in the consumer group.  It will
+// contain the UserData from the JoinGroupRequest (if provided).
+type Member struct {
+	ID       string
+	UserData []byte
 }
 
-func (info topicInfo) Perform(s Strategy) map[string][]int32 {
-	if s == StrategyRoundRobin {
-		return info.RoundRobin()
-	}
-	return info.Ranges()
+// Partition describes a single partition that is to be consumed.
+type Partition struct {
+	Topic  string
+	ID     int32
+	Leader *sarama.Broker
 }
 
-func (info topicInfo) Ranges() map[string][]int32 {
-	sort.Strings(info.MemberIDs)
+// Balancer is a strategy for dividing partitions to be consumed across group
+// members.
+type Balancer interface {
+	// Name is the name of this balancer.  It is sent in the JoinGroupRequest
+	// in the ConsumerGroupMemberMetadata.
+	Name() string
 
-	mlen := len(info.MemberIDs)
-	plen := len(info.Partitions)
-	res := make(map[string][]int32, mlen)
+	// Balancer returns a map of member id to assigned partitions.  This will
+	// only be run on the Consumer Group Leader, and the results will be sent
+	// back to the cluster via the SyncGroupResponse.
+	Balance(members []Member, partitions []Partition) map[string][]int32
 
-	for pos, memberID := range info.MemberIDs {
-		n, i := float64(plen)/float64(mlen), float64(pos)
-		min := int(math.Floor(i*n + 0.5))
-		max := int(math.Floor((i+1)*n + 0.5))
-		sub := info.Partitions[min:max]
-		if len(sub) > 0 {
-			res[memberID] = sub
-		}
-	}
-	return res
+	// UserData is any additional information that should be provided in the
+	// ConsumerGroupMetadata in the JoinGroupRequest.  If the balancer does not
+	// require any custom data, then this function should return nil.
+	UserData() []byte
 }
 
-func (info topicInfo) RoundRobin() map[string][]int32 {
-	sort.Strings(info.MemberIDs)
+var _ Balancer = &builtinBalancer{}
 
-	mlen := len(info.MemberIDs)
-	res := make(map[string][]int32, mlen)
-	for i, pnum := range info.Partitions {
-		memberID := info.MemberIDs[i%mlen]
-		res[memberID] = append(res[memberID], pnum)
-	}
-	return res
+type builtinBalancer struct {
+	name string
+	fn   func(members []Member, partitions []Partition) map[string][]int32
 }
 
-// --------------------------------------------------------------------
-
-type balancer struct {
-	client sarama.Client
-	topics map[string]topicInfo
+func (bb *builtinBalancer) Name() string {
+	return bb.name
 }
 
-func newBalancerFromMeta(client sarama.Client, members map[string]sarama.ConsumerGroupMemberMetadata) (*balancer, error) {
-	balancer := newBalancer(client)
-	for memberID, meta := range members {
-		for _, topic := range meta.Topics {
-			if err := balancer.Topic(topic, memberID); err != nil {
-				return nil, err
-			}
-		}
-	}
-	return balancer, nil
+func (bb *builtinBalancer) Balance(members []Member, partitions []Partition) map[string][]int32 {
+	return bb.fn(members, partitions)
 }
 
-func newBalancer(client sarama.Client) *balancer {
-	return &balancer{
-		client: client,
-		topics: make(map[string]topicInfo),
-	}
-}
-
-func (r *balancer) Topic(name string, memberID string) error {
-	topic, ok := r.topics[name]
-	if !ok {
-		nums, err := r.client.Partitions(name)
-		if err != nil {
-			return err
-		}
-		topic = topicInfo{
-			Partitions: nums,
-			MemberIDs:  make([]string, 0, 1),
-		}
-	}
-	topic.MemberIDs = append(topic.MemberIDs, memberID)
-	r.topics[name] = topic
+func (bb *builtinBalancer) UserData() []byte {
 	return nil
 }
 
-func (r *balancer) Perform(s Strategy) map[string]map[string][]int32 {
+// Range is the default and assigns partition ranges to consumers.
+// Example with six partitions and two consumers:
+//   C1: [0, 1, 2]
+//   C2: [3, 4, 5]
+var Range = &builtinBalancer{
+	name: string(StrategyRange),
+	fn: func(members []Member, partitions []Partition) map[string][]int32 {
+		sort.Slice(members, func(i, j int) bool {
+			return members[i].ID < members[j].ID
+		})
+
+		mlen := len(members)
+		plen := len(partitions)
+		res := make(map[string][]int32, mlen)
+
+		for pos, member := range members {
+			n, i := float64(plen)/float64(mlen), float64(pos)
+			min := int(math.Floor(i*n + 0.5))
+			max := int(math.Floor((i+1)*n + 0.5))
+			sub := partitions[min:max]
+			if len(sub) > 0 {
+				parts := make([]int32, len(sub))
+				for i := range sub {
+					parts[i] = sub[i].ID
+				}
+				res[member.ID] = parts
+			}
+		}
+		return res
+	},
+}
+
+// RoundRobin assigns partitions by alternating over consumers.
+// Example with six partitions and two consumers:
+//   C1: [0, 2, 4]
+//   C2: [1, 3, 5]
+var RoundRobin = &builtinBalancer{
+	name: string(StrategyRoundRobin),
+	fn: func(members []Member, partitions []Partition) map[string][]int32 {
+		sort.Slice(members, func(i, j int) bool {
+			return members[i].ID < members[j].ID
+		})
+
+		mlen := len(members)
+		res := make(map[string][]int32, mlen)
+		for i, pnum := range partitions {
+			memberID := members[i%mlen].ID
+			res[memberID] = append(res[memberID], pnum.ID)
+		}
+		return res
+	},
+}
+
+type topicInfo struct {
+	members    []Member
+	partitions []Partition
+}
+
+func topicInfoFromMetadata(client sarama.Client, members map[string]sarama.ConsumerGroupMemberMetadata) (map[string]topicInfo, error) {
+	topics := make(map[string]topicInfo)
+	for id, meta := range members {
+		for _, name := range meta.Topics {
+			topic, ok := topics[name]
+			if !ok {
+				nums, err := client.Partitions(name)
+				if err != nil {
+					return nil, err
+				}
+				for _, num := range nums {
+					leader, err := client.Leader(name, num)
+					if err != nil {
+						return nil, err
+					}
+					topic.partitions = append(topic.partitions, Partition{
+						Topic:  name,
+						ID:     num,
+						Leader: leader,
+					})
+				}
+			}
+			topic.members = append(topic.members, Member{
+				ID:       id,
+				UserData: meta.UserData,
+			})
+			topics[name] = topic
+		}
+	}
+	return topics, nil
+}
+
+func assign(balancer Balancer, topics map[string]topicInfo) map[string]map[string][]int32 {
 	res := make(map[string]map[string][]int32, 1)
-	for topic, info := range r.topics {
-		for memberID, partitions := range info.Perform(s) {
+	for name, t := range topics {
+		for memberID, partitions := range balancer.Balance(t.members, t.partitions) {
 			if _, ok := res[memberID]; !ok {
 				res[memberID] = make(map[string][]int32, 1)
 			}
-			res[memberID][topic] = partitions
+			res[memberID][name] = partitions
 		}
 	}
 	return res

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -187,6 +187,10 @@ func (m *mockClient) Partitions(t string) ([]int32, error) {
 	return pts, nil
 }
 
+func (*mockClient) Leader(topic string, partition int32) (*sarama.Broker, error) {
+	return nil, nil
+}
+
 func (*mockConsumer) ConsumePartition(topic string, partition int32, offset int64) (sarama.PartitionConsumer, error) {
 	if offset > -1 && offset < 1000 {
 		return nil, sarama.ErrOffsetOutOfRange

--- a/cmd/sarama-cluster-cli/main.go
+++ b/cmd/sarama-cluster-cli/main.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/bsm/sarama-cluster"
 	"github.com/segmentio/sarama"
+	"github.com/segmentio/sarama-cluster"
 )
 
 var (

--- a/examples_test.go
+++ b/examples_test.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"regexp"
 
-	cluster "github.com/bsm/sarama-cluster"
+	cluster "github.com/segmentio/sarama-cluster"
 )
 
 // This example shows how to use the consumer to read messages

--- a/zone_affinity.go
+++ b/zone_affinity.go
@@ -1,0 +1,187 @@
+package cluster
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+var _ Balancer = &ZoneAffinityBalancer{}
+
+// ZoneAffinityBalancer makes a best effort to pair up consumers with partitions
+// where the leader is in the same zone.  Doing so can help from a performance
+// perspective by minimizing round trip latency, and it can also help keep costs
+// down when running in AWS by avoid cross-AZ data transfer.  The primary
+// objective is to spread partitions evenly across consumers with a secondary
+// focus on maximizing the number of partitions where the leader and the
+// consumer are in the same zone.
+//
+// Requires minimum Kafka protocol version of 0.10.0.0 in order to be able to
+// determine the brokers' rack.
+type ZoneAffinityBalancer struct {
+	// Zone is the zone for this consumer.  It will be communicated to the
+	// leader via UserData.  It will be inferred if left unset.  If the zone
+	// cannot be determined, it will be reported as "unknown".
+	Zone string
+
+	lock     sync.Mutex
+}
+
+func (*ZoneAffinityBalancer) Name() string {
+	return "zone-affinity"
+}
+
+func (*ZoneAffinityBalancer) Balance(members []Member, partitions []Partition) map[string][]int32 {
+	zonedPartitions := make(map[string][]int32)
+	for _, part := range partitions {
+		zone := part.Leader.Rack()
+		zonedPartitions[zone] = append(zonedPartitions[zone], part.ID)
+	}
+
+	zonedConsumers := make(map[string][]string)
+	for _, member := range members {
+		zone := string(member.UserData)
+		zonedConsumers[zone] = append(zonedConsumers[zone], member.ID)
+	}
+
+	targetPerMember := len(partitions) / len(members)
+	remainder := len(partitions) % len(members)
+	assignments := make(map[string][]int32)
+
+	// assign as many as possible in zone.  this will assign up to partsPerMember
+	// to each consumer.  it will also prefer to allocate remainder partitions
+	// in zone if possible.
+	for zone, parts := range zonedPartitions {
+
+		consumers := zonedConsumers[zone]
+		if len(consumers) == 0 {
+			continue
+		}
+
+		// don't over-allocate.  cap partition assignments at the calculated
+		// target.
+		partsPerMember := len(parts) / len(consumers)
+		if partsPerMember > targetPerMember {
+			partsPerMember = targetPerMember
+		}
+
+		for _, consumer := range consumers {
+			assignments[consumer] = append(assignments[consumer], parts[:partsPerMember]...)
+			parts = parts[partsPerMember:]
+		}
+
+		// if we had enough partitions for each consumer in this zone to hit its
+		// target, attempt to use any leftover partitions to satisfy the total
+		// remainder by adding at most 1 partition per consumer.
+		leftover := len(parts)
+		if partsPerMember == targetPerMember {
+			if leftover > remainder {
+				leftover = remainder
+			}
+			if leftover > len(consumers) {
+				leftover = len(consumers)
+			}
+			remainder -= leftover
+		}
+
+		// this loop covers the case where we're assigning extra partitions or
+		// if there weren't enough to satisfy the targetPerMember and the zoned
+		// partitions didn't divide evenly.
+		for i := 0; i < leftover; i++ {
+			assignments[consumers[i]] = append(assignments[consumers[i]], parts[i])
+		}
+		parts = parts[leftover:]
+
+		if len(parts) == 0 {
+			delete(zonedPartitions, zone)
+		} else {
+			zonedPartitions[zone] = parts
+		}
+	}
+
+	// assign out remainders regardless of zone.
+	var remaining []int32
+	for _, partitions := range zonedPartitions {
+		remaining = append(remaining, partitions...)
+	}
+
+	for _, member := range members {
+		assigned := assignments[member.ID]
+		delta := targetPerMember - len(assigned)
+		// if it were possible to assign the remainder in zone, it's been taken
+		// care of already.  now we will portion out any remainder to a member
+		// that can take it.
+		if delta >= 0 && remainder > 0 {
+			delta++
+			remainder--
+		}
+		if delta > 0 {
+			assignments[member.ID] = append(assigned, remaining[:delta]...)
+			remaining = remaining[delta:]
+		}
+	}
+
+	return assignments
+}
+
+func (b *ZoneAffinityBalancer) UserData() []byte {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	if b.Zone == "" {
+		b.Zone = findZone()
+		if b.Zone == "" {
+			b.Zone = "unknown"
+		}
+	}
+	return []byte(b.Zone)
+}
+
+func findZone() string {
+	switch whereAmI() {
+	case "aws":
+		return awsAvailabilityZone()
+	}
+	return ""
+}
+
+func whereAmI() string {
+	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
+	for _, path := range [...]string{
+		"/sys/devices/virtual/dmi/id/product_uuid",
+		"/sys/hypervisor/uuid",
+	} {
+		b, err := ioutil.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		s := string(b)
+		switch {
+		case strings.HasPrefix(s, "EC2"), strings.HasPrefix(s, "ec2"):
+			return "aws"
+		}
+	}
+	return "somewhere"
+}
+
+func awsAvailabilityZone() string {
+	client := http.Client{
+		Timeout: time.Second,
+		Transport: &http.Transport{
+			DisableCompression: true,
+			DisableKeepAlives:  true,
+		},
+	}
+	r, err := client.Get("http://169.254.169.254/latest/meta-data/placement/availability-zone")
+	if err != nil {
+		return ""
+	}
+	defer r.Body.Close()
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/zone_affinity_test.go
+++ b/zone_affinity_test.go
@@ -1,0 +1,244 @@
+package cluster
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+	"unsafe"
+
+	"github.com/segmentio/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZoneAffinityBalancer_UserData(t *testing.T) {
+
+	t.Run("unknown zone", func(t *testing.T) {
+		b := ZoneAffinityBalancer{}
+		assert.Equal(t,"unknown", string(b.UserData()), "user data should be 'unknown'")
+	})
+
+	t.Run("override zone", func(t *testing.T) {
+		b := ZoneAffinityBalancer{Zone: "zone1"}
+		assert.Equal(t, "zone1", string(b.UserData()))
+	})
+
+	// todo : figure out if it's worth it to mock the ECS setup
+}
+
+func TestZoneAffinityBalancer_Balance(t *testing.T) {
+
+	b := ZoneAffinityBalancer{}
+
+	brokers := map[string]*sarama.Broker{
+		"z1": brokerWithRack("z1"),
+		"z2": brokerWithRack("z2"),
+		"z3": brokerWithRack("z3"),
+		"":   {},
+	}
+
+	tests := []struct {
+		name            string
+		memberCounts    map[string]int
+		partitionCounts map[string]int
+		result          map[string]map[string]int
+	}{
+		{
+			name: "unknown and known zones",
+			memberCounts: map[string]int{
+				"":   1,
+				"z1": 1,
+				"z2": 1,
+			},
+			partitionCounts: map[string]int{
+				"z1": 5,
+				"z2": 4,
+				"":   9,
+			},
+			result: map[string]map[string]int{
+				"z1": {"": 1, "z1": 5},
+				"z2": {"": 2, "z2": 4},
+				"":   {"": 6},
+			},
+		},
+		{
+			name: "all unknown",
+			memberCounts: map[string]int{
+				"": 5,
+			},
+			partitionCounts: map[string]int{
+				"": 103,
+			},
+			result: map[string]map[string]int{
+				"": {"": 103},
+			},
+		},
+		{
+			name: "remainder stays local",
+			memberCounts: map[string]int{
+				"z1": 3,
+				"z2": 3,
+				"z3": 3,
+			},
+			partitionCounts: map[string]int{
+				"z1": 20,
+				"z2": 19,
+				"z3": 20,
+			},
+			result: map[string]map[string]int{
+				"z1": {"z1": 20},
+				"z2": {"z2": 19},
+				"z3": {"z3": 20},
+			},
+		},
+		{
+			name: "imbalanced partitions",
+			memberCounts: map[string]int{
+				"z1": 1,
+				"z2": 1,
+				"z3": 1,
+			},
+			partitionCounts: map[string]int{
+				"z1": 7,
+				"z2": 0,
+				"z3": 7,
+			},
+			result: map[string]map[string]int{
+				"z1": {"z1": 5},
+				"z2": {"z1": 2, "z3": 2},
+				"z3": {"z3": 5},
+			},
+		},
+		{
+			name: "imbalanced members",
+			memberCounts: map[string]int{
+				"z1": 5,
+				"z2": 3,
+				"z3": 1,
+			},
+			partitionCounts: map[string]int{
+				"z1": 9,
+				"z2": 9,
+				"z3": 9,
+			},
+			result: map[string]map[string]int{
+				"z1": {"z1": 9, "z3": 6},
+				"z2": {"z2": 9},
+				"z3": {"z3": 3},
+			},
+		},
+		{
+			name: "no consumers in zone",
+			memberCounts: map[string]int {
+				"z2": 10,
+			},
+			partitionCounts: map[string]int {
+				"z1": 20,
+				"z3": 19,
+			},
+			result: map[string]map[string]int{
+				"z2": {"z1": 20, "z3": 19},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// create members per the distribution in the test case.
+			var members []Member
+			for zone, count := range tt.memberCounts {
+				for i := 0; i < count; i++ {
+					members = append(members, Member{
+						ID:       zone + ":" + strconv.Itoa(len(members)+1),
+						UserData: []byte(zone),
+					})
+				}
+			}
+
+			// create partitions per the distribution in the test case.
+			var partitions []Partition
+			for zone, count := range tt.partitionCounts {
+				for i := 0; i < count; i++ {
+					partitions = append(partitions, Partition{
+						ID:     int32(len(partitions)),
+						Topic:  "test",
+						Leader: brokers[zone],
+					})
+				}
+			}
+
+			res := b.Balance(members, partitions)
+
+			// verification #1...all members must be assigned and with the
+			// correct load.
+			minLoad := len(partitions) / len(members)
+			maxLoad := minLoad
+			if len(partitions)%len(members) != 0 {
+				maxLoad++
+			}
+			for _, member := range members {
+				assignments, _ := res[member.ID]
+				if len(assignments) < minLoad || len(assignments) > maxLoad {
+					t.Errorf("expected between %d and %d partitions for member %s", minLoad, maxLoad, member.ID)
+				}
+			}
+
+			// verification #2...all partitions are assigned, and the distribution
+			// per source zone matches.
+			partsPerZone := make(map[string]map[string]int)
+			uniqueParts := make(map[int32]struct{})
+			for id, assignments := range res {
+
+				var member Member
+				for _, m := range members {
+					if id == m.ID {
+						member = m
+						break
+					}
+				}
+				assert.NotEmpty(t, member.ID, "invalid member ID returned: %s", id)
+
+				var partition Partition
+				for _, id := range assignments {
+
+					uniqueParts[id] = struct{}{}
+
+					for _, p := range partitions {
+						if p.ID == id {
+							partition = p
+							break
+						}
+					}
+					if assert.NotEmpty(t, partition.Topic, "invalid partition ID returned: %d", id) {
+						counts, ok := partsPerZone[string(member.UserData)]
+						if !ok {
+							counts = make(map[string]int)
+							partsPerZone[string(member.UserData)] = counts
+						}
+						counts[partition.Leader.Rack()]++
+					}
+				}
+			}
+
+			require.Equal(t, len(partitions), len(uniqueParts), "not all partitions were assigned")
+			require.Equal(t, tt.result, partsPerZone, "wrong balanced zones")
+		})
+	}
+}
+
+// brokerWithRack uses reflection to create a Broker with the rack field
+// populated.
+func brokerWithRack(rack string) *sarama.Broker {
+
+	broker := &sarama.Broker{}
+	pointerVal := reflect.ValueOf(broker)
+	val := reflect.Indirect(pointerVal)
+
+	member := val.FieldByName("rack")
+	ptrToRack := unsafe.Pointer(member.UnsafeAddr())
+	realPtrToRack := (**string)(ptrToRack)
+	*realPtrToRack = &rack
+
+	return broker
+}

--- a/zone_affinity_test.go
+++ b/zone_affinity_test.go
@@ -1,8 +1,10 @@
 package cluster
 
 import (
+	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -13,17 +15,25 @@ import (
 
 func TestZoneAffinityBalancer_UserData(t *testing.T) {
 
-	t.Run("unknown zone", func(t *testing.T) {
-		b := ZoneAffinityBalancer{}
-		assert.Equal(t,"unknown", string(b.UserData()), "user data should be 'unknown'")
-	})
+	ci, _ := os.LookupEnv("CI")
+	if ci != "" {
+		// todo : this isn't really portable...
+		t.Run("us-west-2", func(t *testing.T) {
+			b := ZoneAffinityBalancer{}
+			zone := string(b.UserData())
+			assert.True(t, strings.HasPrefix(zone, "us-west-2"), "expected a us-west-2 az but got %s", zone)
+		})
+	} else {
+		t.Run("unknown zone", func(t *testing.T) {
+			b := ZoneAffinityBalancer{}
+			assert.Equal(t,"unknown", string(b.UserData()), "user data should be 'unknown'")
+		})
+	}
 
 	t.Run("override zone", func(t *testing.T) {
 		b := ZoneAffinityBalancer{Zone: "zone1"}
 		assert.Equal(t, "zone1", string(b.UserData()))
 	})
-
-	// todo : figure out if it's worth it to mock the ECS setup
 }
 
 func TestZoneAffinityBalancer_Balance(t *testing.T) {


### PR DESCRIPTION
in order to support this change, first updated sarama-cluster to accept
arbitrary balancing strategies.  the Balancer interface is patterned off its
counterpart in kafka-go to ease a port of this functionality.