### PR TITLE
fix dying consumer deadlock during rebalance (#281)

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -874,7 +874,11 @@ func (c *Consumer) createConsumer(tomb *loopTomb, topic string, partition int32,
 	})
 
 	if c.client.config.Group.Mode == ConsumerModePartitions {
-		c.partitions <- pc
+		select {
+		case c.partitions <- pc:
+		case <-c.dying:
+			pc.Close()
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This is a cherry-pick of the following change into the segment-stable branch:
* segmentio/sarama-cluster@b92bef2

This resolves the final of the 3 issues documented in [F8N-764](https://segment.atlassian.net/browse/F8N-764):
* [hang during `source.Close()`](https://segment.atlassian.net/browse/F8N-764?focusedCommentId=69233&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-69233)

## Testing

I ran Stage Archiver overnight with this change in place & the twice-hourly stopping of the archiver containers, and we didn't have any recurrence of the traceback & orphaned files during shutdown:
* https://github.com/segmentio/terracode-infra/pull/1145
* https://github.com/segmentio/archiver/commit/aba6b3fee9950ec3854ba3e84a72f0d2258427e0