### PR TITLE
fix broken tests (java installation issues & EC2 detection when running on nitro)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   setup:
     working_directory: /go/src/github.com/segmentio/sarama-cluster
     docker:
-      - image: segment/circleci-golang:1.10
+      - image: segment/circleci-golang:1.12
     steps:
       - checkout
       - restore_cache:
@@ -33,7 +33,7 @@ jobs:
   vet:
     working_directory: /go/src/github.com/segmentio/sarama-cluster
     docker:
-      - image: segment/circleci-golang:1.10
+      - image: segment/circleci-golang:1.12
     steps:
       - attach_workspace: { at: . }
       - run: make vet
@@ -41,7 +41,7 @@ jobs:
   test:
     working_directory: /go/src/github.com/segmentio/sarama-cluster
     docker:
-      - image: segment/circleci-golang:1.10
+      - image: segment/circleci-golang:1.12
 
     resource_class: large
     steps:
@@ -49,7 +49,9 @@ jobs:
       - attach_workspace: { at: . }
       - run:
           name: Install Java
-          command: sudo apt install default-jre
+          command: |
+            sudo apt-get update
+            sudo apt install default-jre
       - run:
           name: Test
           command: make test

--- a/zone_affinity_test.go
+++ b/zone_affinity_test.go
@@ -18,6 +18,8 @@ func TestZoneAffinityBalancer_UserData(t *testing.T) {
 	ci, _ := os.LookupEnv("CI")
 	if ci != "" {
 		// todo : this isn't really portable...
+		// NOTE: us-west-2 is simply where the circleci EC2 hosts reside. If this test fails then it's
+		// likely that the EC2-detection logic in zone_affinity.go isn't working for a new EC2 setup.
 		t.Run("us-west-2", func(t *testing.T) {
 			b := ZoneAffinityBalancer{}
 			zone := string(b.UserData())


### PR DESCRIPTION
## fix circle CI test setup issues with installing java

1. Update docker image from `segment/circleci-golang:1.10` to `segment/circleci-golang:1.12`
2. Run `sudo apt-get update` before installing java.

## fix tests to handle new circle CI hosting situation in EC2, where it runs on nitro

Our self-hosted Enterprise Circle CI systems have moved to AWS Nitro systems, so
the test can no longer rely on checking `/sys/hypervisor/uuid` as the `circleci` user.
Furthermore, checking `/sys/devices/virtual/dmi/id/product_uuid` requires root
permissions, so we don't wanna do that either.

Thus we update the AWS location checking by adding a new filepath found in the AWS docs,
which applies if we are on a Nitro system.  Importantly, the contents of the path are
the underlying EC2 instance ID (starting with `i-`), rather than ec2/EC2.

Note that it *seems* that we might not need to use arrays of prefixes to allow for varying
casing in the ec2/EC2 strings (based on the AWS docs and anecdotal observations).  i.e.,

This path's value seems to always be prefixed with an upper-case EC2:

```
circleci@0a76e84337b0:~$ sudo cat /sys/devices/virtual/dmi/id/product_uuid
EC28A00E-494E-85D7-1727-3491CA855E60
```

And this path's value seems to always be prefixed with a lower-case ec2:

```
erik.weathers@workbench-foundation-stage-0be1ca43bed4fda7e:~$ cat /sys/hypervisor/uuid
ec28225f-9640-c72d-5641-948a4a834574
```